### PR TITLE
feat: Add typographic 404 page and ghost footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Playfair_Display, Geist, JetBrains_Mono } from "next/font/google";
 import { ConvexClientProvider } from "./ConvexClientProvider";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import { Toaster } from "@/components/ui/toaster";
+import { Footer } from "@/components/layout/Footer";
 import "./globals.css";
 
 const fontDisplay = Playfair_Display({
@@ -40,7 +41,7 @@ export default function RootLayout({
     <ClerkProvider afterSignOutUrl="/">
       <html lang="en" suppressHydrationWarning>
         <body
-          className={`${fontDisplay.variable} ${fontSans.variable} ${fontMono.variable} font-sans antialiased`}
+          className={`${fontDisplay.variable} ${fontSans.variable} ${fontMono.variable} flex min-h-screen flex-col font-sans antialiased`}
         >
           <ThemeProvider
             attribute="class"
@@ -49,7 +50,8 @@ export default function RootLayout({
             disableTransitionOnChange
           >
             <ConvexClientProvider>
-              {children}
+              <div className="flex-1">{children}</div>
+              <Footer />
               <Toaster />
             </ConvexClientProvider>
           </ThemeProvider>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import { ThemeToggle } from "@/components/shared/ThemeToggle";
+
+export default function NotFound() {
+  return (
+    <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-canvas-bone">
+      {/* Radial gradient background - subtle reading light */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(circle at 30% 40%, var(--color-canvas-bone) 0%, var(--color-canvas-bone-muted) 100%)",
+        }}
+      />
+
+      {/* Dot pattern texture overlay */}
+      <div
+        className="pointer-events-none absolute inset-0 bg-text-ink opacity-25"
+        style={{
+          maskImage: `url("data:image/svg+xml,%3Csvg width='4' height='4' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='1' cy='1' r='0.5' fill='black'/%3E%3C/svg%3E")`,
+          maskRepeat: "repeat",
+          WebkitMaskImage: `url("data:image/svg+xml,%3Csvg width='4' height='4' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='1' cy='1' r='0.5' fill='black'/%3E%3C/svg%3E")`,
+          WebkitMaskRepeat: "repeat",
+        }}
+      />
+
+      {/* Theme Toggle - Top Right */}
+      <div className="absolute right-6 top-6 z-10">
+        <ThemeToggle />
+      </div>
+
+      {/* Main content - centered */}
+      <div className="relative z-10 text-center">
+        {/* MASSIVE 404 */}
+        <h1 className="font-display text-[12rem] leading-none tracking-tighter text-text-ink sm:text-[16rem] lg:text-[20rem]">
+          404
+        </h1>
+
+        {/* Understated copy */}
+        <p className="mb-16 mt-12 text-lg text-text-inkMuted">
+          This page isn&apos;t in our collection
+        </p>
+
+        {/* CTA button - match landing page style */}
+        <Link
+          href="/library"
+          className="inline-flex rounded-md bg-text-ink px-8 py-3 font-sans text-base text-canvas-bone transition-all hover:bg-text-inkMuted"
+        >
+          Return to Library
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,0 +1,14 @@
+export function Footer() {
+  return (
+    <footer className="py-8 text-center">
+      <a
+        href="https://mistystep.io"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-mono text-xs text-text-inkSubtle transition-colors hover:text-text-inkMuted"
+      >
+        a misty step project
+      </a>
+    </footer>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -22,6 +22,14 @@ import type {
   FunctionReference,
 } from "convex/server";
 
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
 declare const fullApi: ApiFromModules<{
   "actions/bookSearch": typeof actions_bookSearch;
   "actions/coverFetch": typeof actions_coverFetch;
@@ -31,30 +39,14 @@ declare const fullApi: ApiFromModules<{
   notes: typeof notes;
   users: typeof users;
 }>;
+declare const fullApiWithMounts: typeof fullApi;
 
-/**
- * A utility for referencing Convex functions in your app's public API.
- *
- * Usage:
- * ```js
- * const myFunctionReference = api.myModule.myFunction;
- * ```
- */
 export declare const api: FilterApi<
-  typeof fullApi,
+  typeof fullApiWithMounts,
   FunctionReference<any, "public">
 >;
-
-/**
- * A utility for referencing Convex functions in your app's internal API.
- *
- * Usage:
- * ```js
- * const myFunctionReference = internal.myModule.myFunction;
- * ```
- */
 export declare const internal: FilterApi<
-  typeof fullApi,
+  typeof fullApiWithMounts,
   FunctionReference<any, "internal">
 >;
 

--- a/convex/_generated/server.d.ts
+++ b/convex/_generated/server.d.ts
@@ -10,6 +10,7 @@
 
 import {
   ActionBuilder,
+  AnyComponents,
   HttpActionBuilder,
   MutationBuilder,
   QueryBuilder,
@@ -18,8 +19,14 @@ import {
   GenericQueryCtx,
   GenericDatabaseReader,
   GenericDatabaseWriter,
+  FunctionReference,
 } from "convex/server";
 import type { DataModel } from "./dataModel.js";
+
+type GenericCtx =
+  | GenericActionCtx<DataModel>
+  | GenericMutationCtx<DataModel>
+  | GenericQueryCtx<DataModel>;
 
 /**
  * Define a query in this Convex app's public API.
@@ -85,12 +92,11 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
 /**
  * Define an HTTP action.
  *
- * The wrapped function will be used to respond to HTTP requests received
- * by a Convex deployment if the requests matches the path and method where
- * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ * This function will be used to respond to HTTP requests received by a Convex
+ * deployment if the requests matches the path and method where this action
+ * is routed. Be sure to route your action in `convex/http.js`.
  *
- * @param func - The function. It receives an {@link ActionCtx} as its first argument
- * and a Fetch API `Request` object as its second.
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export declare const httpAction: HttpActionBuilder;

--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -16,6 +16,7 @@ import {
   internalActionGeneric,
   internalMutationGeneric,
   internalQueryGeneric,
+  componentsGeneric,
 } from "convex/server";
 
 /**
@@ -80,14 +81,10 @@ export const action = actionGeneric;
 export const internalAction = internalActionGeneric;
 
 /**
- * Define an HTTP action.
+ * Define a Convex HTTP action.
  *
- * The wrapped function will be used to respond to HTTP requests received
- * by a Convex deployment if the requests matches the path and method where
- * this action is routed. Be sure to route your httpAction in `convex/http.js`.
- *
- * @param func - The function. It receives an {@link ActionCtx} as its first argument
- * and a Fetch API `Request` object as its second.
- * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument, and a `Request` object
+ * as its second.
+ * @returns The wrapped endpoint function. Route a URL path to this function in `convex/http.js`.
  */
 export const httpAction = httpActionGeneric;


### PR DESCRIPTION
feat: add typographic 404 page and ghost footer

Implement two aesthetic polish components:

- Custom 404 page (app/not-found.tsx)
  - MASSIVE typographic "404" in Playfair Display
  - Match landing page aesthetic (radial gradient, dot overlay)
  - Book-themed copy: "This page isn't in our collection"
  - CTA button to return to library
  - Theme toggle in top-right

- Ghost footer component (components/layout/Footer.tsx)
  - Minimal attribution: "a misty step project"
  - Ghost text (text-text-inkSubtle) with hover brightening
  - Mono font at tiny size
  - Links to mistystep.io

- Layout integration (app/layout.tsx)
  - Add flex column structure to push footer to bottom
  - Import and render Footer globally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a custom 404 error page with styled interface, including a theme toggle and navigation button to return users to main content.
  * Added a persistent footer across all application pages with a link to external resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->