### PR TITLE
ci: add PR size labeler and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+  # npm/pnpm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Group minor/patch updates to reduce PR noise
+      production:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    # Ignore major bumps for stability (review manually)
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci(deps)"

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,27 @@
+name: PR Size Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: "size/XS"
+          xs_max_size: 10
+          s_label: "size/S"
+          s_max_size: 100
+          m_label: "size/M"
+          m_max_size: 200
+          l_label: "size/L"
+          l_max_size: 400
+          xl_label: "size/XL"
+          message_if_xl: >
+            ⚠️ This PR is quite large (>400 lines). Consider splitting into smaller PRs for easier review.


### PR DESCRIPTION
## Summary
- Add **PR size labeler** workflow: Auto-labels PRs as XS/S/M/L/XL based on line count
- Add **Dependabot** configuration: Weekly dependency updates with grouped minor/patch PRs

## Details

### PR Size Labeler
- XS: ≤10 lines
- S: ≤100 lines  
- M: ≤200 lines (ideal)
- L: ≤400 lines (acceptable)
- XL: >400 lines (warning to split)

### Dependabot
- Weekly on Monday at 9am PT
- Groups minor/patch updates to reduce noise
- Ignores major versions (manual review)
- 5 PR limit
- Conventional commit prefixes (`chore(deps)`, `ci(deps)`)

## Test plan
- [ ] Merge PR and verify size label appears
- [ ] Wait for Dependabot to create first PR (within 24 hours)
- [ ] Verify coverage report posts (already configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates with weekly scheduling and intelligent grouping to reduce notification noise.
  * Added automated pull request size labeling to enhance code review workflow efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->