### PR TITLE
fix(ux): add toast notifications for silent mutation failures

### DIFF
--- a/components/book/BookDetail.tsx
+++ b/components/book/BookDetail.tsx
@@ -89,6 +89,11 @@ export function BookDetail({ bookId }: BookDetailProps) {
     } catch (err) {
       console.error(err);
       setLocalStatus(book.status);
+      toast({
+        title: "Failed to update status",
+        description: "The reading status couldn't be changed. Please try again.",
+        variant: "destructive",
+      });
     }
   };
 
@@ -98,6 +103,11 @@ export function BookDetail({ bookId }: BookDetailProps) {
       await toggleFavorite({ id: book._id });
     } catch (err) {
       console.error(err);
+      toast({
+        title: "Failed to update favorite",
+        description: "Couldn't update favorite status. Please try again.",
+        variant: "destructive",
+      });
     } finally {
       setIsTogglingFavorite(false);
     }
@@ -109,6 +119,11 @@ export function BookDetail({ bookId }: BookDetailProps) {
       await updateBook({ id: book._id, isAudiobook: !book.isAudiobook });
     } catch (err) {
       console.error(err);
+      toast({
+        title: "Failed to update audiobook status",
+        description: "Couldn't mark as audiobook. Please try again.",
+        variant: "destructive",
+      });
     } finally {
       setIsTogglingAudiobook(false);
     }
@@ -124,6 +139,11 @@ export function BookDetail({ bookId }: BookDetailProps) {
     } catch (err) {
       console.error(err);
       setLocalPrivacy(previousPrivacy);
+      toast({
+        title: "Failed to update privacy",
+        description: "Couldn't change privacy setting. Please try again.",
+        variant: "destructive",
+      });
     } finally {
       setIsTogglingPrivacy(false);
     }

--- a/components/notes/CreateNote.tsx
+++ b/components/notes/CreateNote.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Surface } from "@/components/ui/Surface";
 import { cn } from "@/lib/utils";
 import { Loader2 } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
 
 type CreateNoteProps = {
   bookId: Id<"books">;
@@ -18,6 +19,7 @@ type CreateNoteProps = {
 
 export function CreateNote({ bookId }: CreateNoteProps) {
   const createNote = useMutation(api.notes.create);
+  const { toast } = useToast();
   const [content, setContent] = useState("");
   const [type, setType] = useState<NoteType>("note");
   const [page, setPage] = useState("");
@@ -61,7 +63,12 @@ export function CreateNote({ bookId }: CreateNoteProps) {
       setIsExpanded(false);
     } catch (err) {
       console.error("Failed to create note:", err);
-      // TODO: Toast error
+      toast({
+        title: "Failed to save note",
+        description: "Your note wasn't saved. Please try again.",
+        variant: "destructive",
+      });
+      // Content preserved in editor so user can retry
     } finally {
       setIsSaving(false);
     }

--- a/components/notes/NoteCard.tsx
+++ b/components/notes/NoteCard.tsx
@@ -10,7 +10,8 @@ import { Button } from "@/components/ui/button";
 import { Editor } from "./Editor";
 import { NoteTypeSelector, NoteType } from "./NoteTypeSelector";
 import { cn } from "@/lib/utils";
-import { Pencil, Trash2, Loader2, X, Check } from "lucide-react";
+import { Pencil, Trash2, Loader2 } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
 
 type NoteCardProps = {
   note: Doc<"notes">;
@@ -34,6 +35,7 @@ const TYPE_STYLES: Record<NoteType, { label: string; className: string }> = {
 export function NoteCard({ note }: NoteCardProps) {
   const updateNote = useMutation(api.notes.update);
   const deleteNote = useMutation(api.notes.remove);
+  const { toast } = useToast();
 
   const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -56,6 +58,11 @@ export function NoteCard({ note }: NoteCardProps) {
       setIsEditing(false);
     } catch (err) {
       console.error("Failed to update note:", err);
+      toast({
+        title: "Failed to update note",
+        description: "Your changes weren't saved. Please try again.",
+        variant: "destructive",
+      });
     } finally {
       setIsSaving(false);
     }
@@ -68,6 +75,11 @@ export function NoteCard({ note }: NoteCardProps) {
       await deleteNote({ id: note._id });
     } catch (err) {
       console.error("Failed to delete note:", err);
+      toast({
+        title: "Failed to delete note",
+        description: "The note couldn't be deleted. Please try again.",
+        variant: "destructive",
+      });
       setIsSaving(false);
     }
   };


### PR DESCRIPTION
## Summary
- Add destructive toast notifications to all mutation catch blocks in CreateNote, NoteCard, and BookDetail components
- Users now receive immediate feedback when operations fail instead of silent failures
- Content preserved in editors on failure so users can retry without losing work

## Files Changed
- `components/notes/CreateNote.tsx` - Toast on note creation failure
- `components/notes/NoteCard.tsx` - Toasts on update and delete failures
- `components/book/BookDetail.tsx` - Toasts on status, favorite, audiobook, and privacy toggle failures

## Test plan
- [ ] Simulate network failure → verify toast appears
- [ ] Verify content remains in editors after failure
- [ ] Confirm optimistic updates revert correctly with toast feedback

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error notifications for failed book operations (status, favorite, audiobook, and privacy updates).
  * Added error notifications for failed note operations (creation, updates, and deletions).
  * Note content is now preserved when save attempts fail, allowing easy retry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->