### PR TITLE
fix(ux): replace native confirm with AlertDialog for note deletion

### DIFF
--- a/components/notes/NoteCard.tsx
+++ b/components/notes/NoteCard.tsx
@@ -12,6 +12,17 @@ import { NoteTypeSelector, NoteType } from "./NoteTypeSelector";
 import { cn } from "@/lib/utils";
 import { Pencil, Trash2, Loader2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 
 type NoteCardProps = {
   note: Doc<"notes">;
@@ -39,6 +50,7 @@ export function NoteCard({ note }: NoteCardProps) {
 
   const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   // Edit State
   const [content, setContent] = useState(note.content);
@@ -69,10 +81,10 @@ export function NoteCard({ note }: NoteCardProps) {
   };
 
   const handleDelete = async () => {
-    if (!confirm("Are you sure you want to delete this note?")) return;
-    setIsSaving(true); // visually indicate work
+    setIsSaving(true);
     try {
       await deleteNote({ id: note._id });
+      setShowDeleteDialog(false);
     } catch (err) {
       console.error("Failed to delete note:", err);
       toast({
@@ -117,15 +129,33 @@ export function NoteCard({ note }: NoteCardProps) {
           </div>
 
           <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleDelete}
-              className="text-accent-ember hover:bg-accent-ember/10 hover:text-accent-ember mr-auto sm:mr-0"
-              title="Delete note"
-            >
-              <Trash2 className="h-4 w-4" />
-            </Button>
+            <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-accent-ember hover:bg-accent-ember/10 hover:text-accent-ember mr-auto sm:mr-0"
+                  title="Delete note"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete this note?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will permanently delete this {meta.label.toLowerCase()}. This cannot be
+                    undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={isSaving}>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleDelete} disabled={isSaving}>
+                    {isSaving ? "Deleting…" : "Delete Forever"}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
             <div className="h-4 w-px bg-line-ghost hidden sm:block" />
             <Button
               variant="ghost"


### PR DESCRIPTION
## Summary
- Replace browser's jarring native `confirm()` with custom AlertDialog matching design system
- Shows note type (note/quote/reflection) in confirmation message
- Maintains consistent UX with book deletion confirmation

Closes #55

## Changes
- `components/notes/NoteCard.tsx`: Added AlertDialog with proper state management

## Test Plan
- [x] Lint passes
- [x] Type check passes
- [x] Unit tests pass (35 test files)
- [ ] Manual: Click delete on a note → confirm dialog appears
- [ ] Manual: Cancel dismisses dialog without deletion
- [ ] Manual: Delete Forever removes note with toast confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the note deletion experience by replacing the browser confirmation prompt with a dedicated confirmation dialog. Users can now cancel or confirm deletion ("Delete Forever") within a structured modal interface with clear labeling and proper state handling during the deletion process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->