### PR TITLE
feat(seo): add OG image and meta tags for social sharing

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -1,5 +1,6 @@
-/* eslint-disable design-tokens/no-raw-design-values */
+/* eslint-disable design-tokens/no-raw-design-values -- OG images require explicit pixel dimensions for external renderers */
 import { ImageResponse } from "next/og";
+import { designTokens } from "@/lib/design/tokens.generated";
 
 export const runtime = "edge";
 
@@ -7,98 +8,102 @@ const WIDTH = 1200;
 const HEIGHT = 630;
 
 export async function GET() {
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          height: "100%",
-          width: "100%",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          backgroundColor: "#FDFBF7", // canvas-bone
-          fontFamily: "system-ui, sans-serif",
-          position: "relative",
-        }}
-      >
-        {/* Subtle dot pattern texture */}
+  try {
+    return new ImageResponse(
+      (
         <div
           style={{
-            position: "absolute",
-            inset: 0,
-            opacity: 0.03,
-            backgroundImage: `url("data:image/svg+xml,%3Csvg width='4' height='4' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='1' cy='1' r='0.5' fill='black'/%3E%3C/svg%3E")`,
-            backgroundRepeat: "repeat",
-          }}
-        />
-
-        {/* Main content */}
-        <div
-          style={{
+            height: "100%",
+            width: "100%",
             display: "flex",
             flexDirection: "column",
             alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: designTokens.colors.canvas.bone,
+            fontFamily: "system-ui, sans-serif",
+            position: "relative",
           }}
         >
-          {/* Book icon */}
-          <svg
-            width="80"
-            height="80"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="#1A1A1A"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            style={{ marginBottom: "32px", opacity: 0.6 }}
-          >
-            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
-            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
-          </svg>
-
-          {/* Title */}
+          {/* Subtle dot pattern texture */}
           <div
             style={{
-              fontSize: "72px",
-              fontWeight: 700,
-              color: "#1A1A1A", // text-ink
-              letterSpacing: "-2px",
-              marginBottom: "16px",
+              position: "absolute",
+              inset: 0,
+              opacity: 0.03,
+              backgroundImage: `url("data:image/svg+xml,%3Csvg width='4' height='4' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='1' cy='1' r='0.5' fill='black'/%3E%3C/svg%3E")`,
+              backgroundRepeat: "repeat",
             }}
-          >
-            bibliomnomnom
-          </div>
+          />
 
-          {/* Tagline */}
+          {/* Main content */}
           <div
             style={{
-              fontSize: "28px",
-              color: "#666666", // text-inkMuted
-              letterSpacing: "4px",
-              textTransform: "uppercase",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
             }}
           >
-            for voracious readers
+            {/* Book icon */}
+            <svg
+              width="80"
+              height="80"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke={designTokens.colors.text.ink}
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              style={{ marginBottom: "32px", opacity: 0.6 }}
+            >
+              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+              <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+            </svg>
+
+            {/* Title */}
+            <div
+              style={{
+                fontSize: "72px",
+                fontWeight: 700,
+                color: designTokens.colors.text.ink,
+                letterSpacing: "-2px",
+                marginBottom: "16px",
+              }}
+            >
+              bibliomnomnom
+            </div>
+
+            {/* Tagline */}
+            <div
+              style={{
+                fontSize: "28px",
+                color: designTokens.colors.text.inkMuted,
+                letterSpacing: "4px",
+                textTransform: "uppercase",
+              }}
+            >
+              for voracious readers
+            </div>
           </div>
+
+          {/* Decorative bottom line */}
+          <div
+            style={{
+              position: "absolute",
+              bottom: "60px",
+              width: "100px",
+              height: "2px",
+              backgroundColor: designTokens.colors.text.ink,
+              opacity: 0.2,
+            }}
+          />
         </div>
-
-        {/* Decorative bottom line */}
-        <div
-          style={{
-            position: "absolute",
-            bottom: "60px",
-            width: "100px",
-            height: "2px",
-            backgroundColor: "#1A1A1A",
-            opacity: 0.2,
-          }}
-        />
-      </div>
-    ),
-    {
-      width: WIDTH,
-      height: HEIGHT,
-    },
-  );
+      ),
+      {
+        width: WIDTH,
+        height: HEIGHT,
+      },
+    );
+  } catch {
+    return new Response("Failed to generate OG image", { status: 500 });
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ const fontMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://bibliomnomnom.com"),
+  metadataBase: new URL(process.env.SITE_URL || "https://bibliomnomnom.com"),
   title: {
     default: "bibliomnomnom",
     template: "%s | bibliomnomnom",
@@ -37,9 +37,6 @@ export const metadata: Metadata = {
   description: "A digital garden for voracious readers",
   manifest: "/manifest.webmanifest",
   openGraph: {
-    title: "bibliomnomnom",
-    description: "A digital garden for voracious readers",
-    url: "https://bibliomnomnom.com",
     siteName: "bibliomnomnom",
     type: "website",
     images: [
@@ -53,8 +50,6 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "bibliomnomnom",
-    description: "A digital garden for voracious readers",
     images: ["/api/og"],
   },
 };


### PR DESCRIPTION
## Summary

- Add comprehensive OpenGraph and Twitter Card meta tags to root layout
- Create dynamic `/api/og` route for site-wide OG image generation
- Set `metadataBase` for absolute URL resolution
- Add title template for consistent page titles across the app

## Changes

| File | Change |
|------|--------|
| `app/layout.tsx` | Added `openGraph`, `twitter`, `metadataBase`, and title template to metadata |
| `app/api/og/route.tsx` | New edge route that generates branded OG image dynamically |

## Technical Details

The OG image route uses `next/og` (ImageResponse) to generate a 1200x630px image featuring:
- Subtle paper texture matching the app's aesthetic
- Book icon, title "bibliomnomnom", and tagline
- Design system colors (canvas-bone, text-ink)

## Testing

- [ ] Verify with [opengraph.xyz](https://www.opengraph.xyz/) 
- [ ] Test Twitter Card Validator
- [ ] Test LinkedIn Post Inspector

## Screenshots

N/A - OG images are dynamically generated

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Open Graph image generation for social sharing, featuring bibliomnomnom branding, a title, tagline, and decorative styling.
  * Expanded social metadata (Open Graph and Twitter Card) with site-wide defaults to improve link previews and consistency across platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->