### PR TITLE
fix(book): resolve upload cover button not working on book detail page

### DIFF
--- a/components/book/BookCoverManager.tsx
+++ b/components/book/BookCoverManager.tsx
@@ -265,15 +265,15 @@ export function BookCoverManager({
                       </Button>
                       <label
                         className={cn(
-                          buttonVariants({ variant: "secondary", size: "sm" }),
-                          "w-full cursor-pointer",
+                          buttonVariants({ variant: "secondary", size: "sm", fullWidth: true }),
+                          "cursor-pointer",
                         )}
                       >
                         <input
                           type="file"
                           accept={ALLOWED_TYPES.join(",")}
                           onChange={handleFileUpload}
-                          className="hidden"
+                          className="sr-only"
                           disabled={isUploading}
                         />
                         <Upload className="w-3.5 h-3.5 mr-2" />
@@ -332,15 +332,15 @@ export function BookCoverManager({
                   </Button>
                   <label
                     className={cn(
-                      buttonVariants({ variant: "secondary" }),
-                      "w-full cursor-pointer justify-start border border-dashed border-line-ember bg-transparent text-text-inkMuted hover:bg-canvas-boneMuted hover:text-text-ink",
+                      buttonVariants({ variant: "ghost", fullWidth: true }),
+                      "cursor-pointer justify-start border border-dashed border-line-ember text-text-inkMuted hover:text-text-ink",
                     )}
                   >
                     <input
                       type="file"
                       accept={ALLOWED_TYPES.join(",")}
                       onChange={handleFileUpload}
-                      className="hidden"
+                      className="sr-only"
                       disabled={isUploading}
                     />
                     <Upload className="w-3.5 h-3.5 mr-2" />


### PR DESCRIPTION
## Summary
- Fixed the "Upload File" button not working when trying to change a book cover on the book detail page
- Root cause: programmatic `fileInputRef.current?.click()` can be blocked by browsers due to security restrictions around file inputs

## Changes
- Replaced `Button` + programmatic click with `<label>` wrapping a hidden file input
- Used `buttonVariants` to maintain the same visual appearance
- Removed unused `fileInputRef` and top-level hidden input

## Test plan
- [ ] Navigate to a book with an existing cover
- [ ] Hover over the cover image
- [ ] Click "Upload File" button
- [ ] Verify file picker dialog opens
- [ ] Select an image and verify it uploads successfully
- [ ] Test on a book without a cover (the no-cover state buttons)

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved book cover upload interface: upload areas are now clickable label-wrapped controls (no hidden triggers), making file selection more discoverable.
  * Consistent button styling applied to new upload controls for a unified visual experience.
  * Upload triggers updated across hover and non-hover states while preserving existing upload behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->