### PR TITLE
refactor(health): extract probe count to named constant

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -61,8 +61,11 @@ export const GET = withObservability(
   },
 );
 
+/** Number of service probes - update when adding/removing probes below */
+const PROBE_COUNT = 3;
+
 async function runProbesWithinBudget() {
-  const perProbe = OVERALL_TIMEOUT_MS / 3;
+  const perProbe = OVERALL_TIMEOUT_MS / PROBE_COUNT;
 
   const [convex, clerk, stripe] = await Promise.all([
     probeConvex(process.env.NEXT_PUBLIC_CONVEX_URL, perProbe),


### PR DESCRIPTION
## Summary
Closes #123

Replaces the magic number `3` in health probe timeout calculation with a documented `PROBE_COUNT` constant.

## Changes
- Extract `PROBE_COUNT = 3` as module-level constant
- Add JSDoc comment explaining to update when adding/removing probes

## Notes
The issue suggested using `probes.length` dynamically, but TypeScript's tuple inference made that approach type-unsafe (returned `ServiceCheckResult | undefined`). This simpler approach documents the dependency clearly while preserving full type safety.

---
*Automated PR from Kaylee 🛠️*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code maintainability in the health check endpoint through code organization updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->