### PR TITLE
fix(ci): use GH_RELEASE_TOKEN for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run semantic-release
         id: semantic
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
         run: pnpm release
 
   generate-content:


### PR DESCRIPTION
## Problem
semantic-release uses `GITHUB_TOKEN` which is the github-actions[bot] token. Our org-wide branch protection ruleset requires PRs to push to master. When semantic-release tries to push version bumps + CHANGELOG.md, it gets rejected (GH013).

## Fix
Use `GH_RELEASE_TOKEN` org secret (kaylee-mistystep's token with admin bypass rights) instead of `GITHUB_TOKEN` for the release step.

## Context
- Org ruleset: Production Branch Protection (ID 12509021)
- Only admin roles can bypass the PR requirement
- `GH_RELEASE_TOKEN` is set as an org-wide secret with visibility to all repos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. Internal infrastructure updates were made to improve release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->