### PR TITLE
Add Convex tests for listening sessions state machine

### DIFF
--- a/__tests__/convex/listeningSessions.test.ts
+++ b/__tests__/convex/listeningSessions.test.ts
@@ -379,7 +379,7 @@ describe("listening session state machine handlers", () => {
         sessionId: SESSION_ID,
         transcript: "There is audio",
       }),
-    ).rejects.toThrow("Cannot complete session from state: recording");
+    ).rejects.toThrow("Invalid session transition from recording to complete");
   });
 
   it("creates raw transcript note when missing and updates session on completion", async () => {

--- a/convex/listeningSessions.ts
+++ b/convex/listeningSessions.ts
@@ -239,9 +239,7 @@ export const completeListeningSessionHandler = async (
   const session = await getOwnedSession(ctx, userId, args.sessionId);
   await getOwnedBook(ctx, userId, session.bookId);
 
-  if (!["transcribing", "synthesizing", "review", "complete"].includes(session.status)) {
-    throw new ConvexError(`Cannot complete session from state: ${session.status}`);
-  }
+  assertTransition(session.status, "complete");
 
   const now = Date.now();
   const cleanedTranscript = args.transcript.trim();


### PR DESCRIPTION
## Summary
- Extracted listening session mutation logic into exported handlers in `convex/listeningSessions.ts` to make the state machine directly testable.
- Added a focused `Vitest` suite for transition and completion behavior in `__tests__/convex/listeningSessions.test.ts`.

## Why
The listening session lifecycle (`create -> markTranscribing -> markSynthesizing -> complete/fail`) was not explicitly covered by unit tests, so regressions in transition guards and note synthesis behavior could slip through.

## What changed
- Added exported handlers:
  - `createListeningSessionHandler`
  - `markTranscribingHandler`
  - `markSynthesizingHandler`
  - `completeListeningSessionHandler`
  - `failListeningSessionHandler`
- Wired existing mutations to call these handlers.
- Added tests for:
  - `create` normalization
  - valid/invalid `markTranscribing` transitions
  - valid/invalid `markSynthesizing` transitions
  - `complete` transcript validation and state checks
  - raw transcript note create/update
  - synthesized note cap + quote dedupe behavior
  - `fail` error truncation

Closes #157


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for the full listening-session lifecycle: creation, transcribing, synthesizing, completion, failure, transcript handling, raw note updates, and DB mutation validation.

* **New Features**
  * More reliable transcript handling, truncation safeguards, cap/dedup logic, and automatic generation/updating of synthesized and raw notes on completion.

* **Bug Fixes**
  * Improved ownership checks, clearer error reporting, and stricter invalid-transition handling.

* **Refactor**
  * Centralized lifecycle handlers for clearer, more robust state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Before / After

Before:
- Listening session lifecycle/state machine not directly covered by handler-level unit tests.
- `completeListeningSessionHandler` could patch an existing `rawNoteId` without validating note ownership/book invariant.
- `failListeningSessionHandler` allowed invalid transitions (e.g. `complete -> failed`).
- Test harness still had some missing negative/regression cases.

After:
- Handler-level Vitest coverage for transitions + completion edge cases.
- `rawNoteId` update validates note belongs to the same user + same book (else `ConvexError`).
- `failListeningSessionHandler` enforces `ALLOWED_TRANSITIONS` via `assertTransition`.
- `completeListeningSessionHandler` uses `assertTransition` for the completion transition guard.
- Added focused regression tests for these cases.

