### PR TITLE
docs: refocus product priorities around tracking, voice, and profiles

### DIFF
--- a/DISTRIBUTION-READINESS.md
+++ b/DISTRIBUTION-READINESS.md
@@ -1,5 +1,8 @@
 # bibliomnomnom Distribution Readiness Guide
 
+> Scope note: this document is deployment/distribution operations only.
+> Product build priorities now live in `docs/PRODUCT-PRIORITIES.md`.
+
 **Current Status:** 77% ready (as of 2026-02-02)
 **Target:** 100% production-ready
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ A digital garden for voracious readers—a beautiful, private-first book trackin
 
 **Why bibliomnomnom?** Track your reading journey with a privacy-first approach. Unlike Goodreads or StoryGraph, your data stays yours. Built for readers who want a beautiful, intentional way to catalog books, notes, and quotes without algorithms or social pressure.
 
+## Current Product Focus
+
+Primary outcomes:
+
+1. Make read/currently-reading/want-to-read tracking effortless.
+2. Make voice note capture + synthesis secure and reliable.
+3. Deliver insightful reader profiles + strong recommendations from reading states and voice context.
+
+Current prioritized backlog and issue mapping lives in:
+- [docs/PRODUCT-PRIORITIES.md](./docs/PRODUCT-PRIORITIES.md)
+
 ## Prerequisites
 
 - **Node.js** >=20.9.0
@@ -427,5 +438,6 @@ See [DESIGN-SYSTEM.md](./DESIGN-SYSTEM.md) for complete token documentation.
 - **[CLAUDE.md](./CLAUDE.md)** - Patterns, conventions, troubleshooting
 - **[DEPLOYMENT.md](./DEPLOYMENT.md)** - Production deployment guide for Vercel/Convex/Clerk
 - **[DESIGN-SYSTEM.md](./DESIGN-SYSTEM.md)** - Design tokens, colors, typography
+- **[docs/PRODUCT-PRIORITIES.md](./docs/PRODUCT-PRIORITIES.md)** - current product priorities + backlog focus
 - **[docs/adr/](./docs/adr/)** - Architecture Decision Records
 - **[docs/flows/](./docs/flows/)** - User journey diagrams

--- a/docs/PRODUCT-PRIORITIES.md
+++ b/docs/PRODUCT-PRIORITIES.md
@@ -1,0 +1,101 @@
+# Product Priorities
+
+Last updated: 2026-02-19
+
+This is the source of truth for what we build next.
+
+## Primary User Outcomes
+
+1. Track books fast and accurately across three lists:
+   - read
+   - currently-reading
+   - want-to-read
+2. Capture reading notes by voice, then turn them into useful synthesized notes.
+3. Generate genuinely insightful reader profiles and recommendations from:
+   - reading history (read)
+   - active momentum (currently-reading)
+   - stated intent (want-to-read)
+   - voice-note synthesis artifacts
+
+## Pillar 1: Core Tracking (P1)
+
+Epic: #165
+
+### Goal
+
+Make status tracking feel instant, obvious, and trustworthy.
+
+### `now`
+
+- #169 Tracking UX: first-class read/currently-reading/want-to-read lanes
+- #36 External book search (Google Books API)
+- #34 Export library to JSON/CSV/Markdown
+
+### `next`
+
+- #32 Queue sorting: date, alphabetical, shuffle
+- #60 CMD+K command palette for library search
+- #56 Improve form validation and error messages
+- #54 Consolidate book filtering to single pass
+
+## Pillar 2: Voice Notes + Synthesis (P1)
+
+Epic: #166
+
+### Goal
+
+One-tap voice capture that is secure, durable, and useful.
+
+### `now`
+
+- #160 Listening sessions: make audio blobs private
+- #159 Listening sessions: durable server-side processing + retry
+- #147 [Listening Sessions] Implement resilient audio capture and chunk upload
+- #146 [Listening Sessions] Build recording UX on book detail page
+- #145 [Listening Sessions] Add Convex data model and state machine
+- #144 [Listening Sessions] STT benchmark + provider decision matrix
+
+### `next`
+
+- #158 Add tests for listening session recorder lifecycle
+- #155 [Listening Sessions] Add reliability test suite for long sessions and rollover
+- #154 [Listening Sessions] Add observability, fallback telemetry, and cost guardrails
+- #153 [Listening Sessions] Build synthesis review and publish workflow
+- #152 [Listening Sessions] Build context packer for personalized synthesis
+- #151 [Listening Sessions] Implement multi-stage synthesis pipeline with schema validation
+- #150 [Listening Sessions] Persist transcripts and auto-save raw transcript notes
+- #149 [Listening Sessions] Build STT gateway with provider adapters and fallback policy
+
+## Pillar 3: Profile Intelligence + Recommendations (P1)
+
+Epic: #167
+
+### Goal
+
+Recommendations should feel specific, personal, and explainable.
+
+### `next`
+
+- #170 Profile intelligence: weight read/currently-reading/want-to-read signals explicitly
+- #168 Recommendations: incorporate voice-note synthesis artifacts into profile context
+- #33 AI-powered reading recommendations
+- #77 AI Features Phase 1: embeddings, semantic search, recommendations
+- #59 Public user profiles
+- #57 Reading analytics dashboard
+
+## What Is Deprioritized
+
+These stay in backlog until they support one of the three primary outcomes:
+
+- launch channel tasks (#91, #92)
+- monetization/packaging expansion (#82, #89)
+- platform expansion (#78, #108)
+- non-essential polish bundles (#72, #83)
+
+## Backlog Policy
+
+- `now`: directly unblocks one of the three primary outcomes in current sprint.
+- `next`: important follow-up after current blockers land.
+- `later`: not in active planning horizon.
+
+If work does not clearly improve one of the three primary outcomes, default it to `later`.

--- a/docs/flows/README.md
+++ b/docs/flows/README.md
@@ -2,6 +2,16 @@
 
 Mermaid diagrams for complex state machines and data flows in bibliomnomnom.
 
+## Priority Flows (Current)
+
+These are directly tied to active product pillars in `docs/PRODUCT-PRIORITIES.md`.
+
+| Pillar                    | Flow               | File                                             |
+| ------------------------- | ------------------ | ------------------------------------------------ |
+| Core tracking             | Add Book Sheet     | [add-book-sheet.md](./add-book-sheet.md)         |
+| Voice notes + synthesis   | Listening Sessions | [listening-sessions.md](./listening-sessions.md) |
+| Profile + recommendations | Profile Generation | [profile-generation.md](./profile-generation.md) |
+
 ## Documented Flows
 
 ### Complex State Machines (Diagrammed)

--- a/docs/flows/listening-sessions.md
+++ b/docs/flows/listening-sessions.md
@@ -2,6 +2,12 @@
 
 Voice-first note capture for readers who want to keep reading while talking through reactions, ideas, and questions.
 
+Current backlog focus for this flow is tracked under pillar epic #166:
+
+1. Security and trust first (`#160` private audio blobs)
+2. Durability and retry (`#159` server-side recoverability)
+3. Capture and UX reliability (`#147`, `#146`, `#145`)
+
 ## Goals
 
 - One-tap recording from book detail.

--- a/docs/flows/profile-generation.md
+++ b/docs/flows/profile-generation.md
@@ -2,6 +2,8 @@
 
 The ProfilePage component (`components/profile/ProfilePage.tsx`) manages AI-powered profile generation with multiple states.
 
+Current profile threshold in code is `20` books (`convex/profiles.ts`), not 5.
+
 ## State Machine
 
 ```mermaid
@@ -9,7 +11,7 @@ stateDiagram-v2
     [*] --> loading: Component mounts
 
     loading --> unauthenticated: No user
-    loading --> below_threshold: < 5 books
+    loading --> below_threshold: < 20 books
     loading --> no_profile: User has no profile
     loading --> generating: Profile being generated
     loading --> failed: Previous generation failed
@@ -24,7 +26,7 @@ stateDiagram-v2
 
     note right of below_threshold
         Shows ProfileThreshold component
-        with book count and target (5)
+        with book count and target (20)
     end note
 
     note right of generating
@@ -38,15 +40,28 @@ stateDiagram-v2
     end note
 ```
 
+## Input Signals (Current vs Next)
+
+Current generation context includes:
+
+- read books
+- currently-reading books
+- want-to-read books
+- favorites, audiobook flags, rereads, recent completion timing
+
+Next planned context expansion:
+
+- voice-note synthesis artifacts (see #168)
+
 ## Query Response Shape
 
 ```typescript
 type ProfileQueryResult =
   | { status: "unauthenticated" }
   | { status: "below_threshold"; bookCount: number; booksNeeded: number }
-  | { status: "no_profile"; bookCount: number }
-  | { status: "generating" }
-  | { status: "failed"; error: string }
+  | { status: "no_profile"; bookCount: number; stats: ProfileStats }
+  | { status: "generating"; bookCount: number; profile?: ProfilePreview }
+  | { status: "failed"; bookCount: number; error: string; profile: ProfilePreview }
   | {
       status: "ready";
       profile: Profile;
@@ -96,4 +111,4 @@ When regenerating an existing profile:
 | --------------------------- | ----------------------------------------------- |
 | `failed`                    | "Try Again" button -> calls `generateProfile()` |
 | Network error in generation | Toast shown, `isPending` reset                  |
-| Below threshold             | User must add more books                        |
+| Below threshold             | User must add more books (20 total required)    |


### PR DESCRIPTION
## Summary
Refocuses repo documentation and backlog structure around three core product outcomes:
1. Track read/currently-reading/want-to-read with low friction
2. Capture voice notes and synthesize them reliably
3. Generate profile insights and recommendations from reading state + voice context

## What changed
- Added `docs/PRODUCT-PRIORITIES.md` as source of truth for `now/next/later`
- Updated `README.md` with an explicit current product focus section
- Updated flow docs to align with active pillars and current code reality:
  - profile threshold/docs corrected to 20 books
  - profile signal inputs clarified
  - listening sessions flow linked to active security/reliability priorities
- Added scope boundary note in `DISTRIBUTION-READINESS.md` so it stays ops-focused

## Backlog alignment (already applied in GitHub issues)
- Added pillar labels: `pillar/tracking`, `pillar/voice-notes`, `pillar/profile-recs`
- Added epics: #165, #166, #167
- Added focused child issues: #168, #169, #170
- Reprioritized launch-channel issues to later while moving core-product work to now/next

## Why
The backlog had competing directions. This codifies one strategy so execution stays tied to core product value.

## Validation
- `bun run validate:fast`
- Pre-push hooks also ran full `test` + `build`
