### PR TITLE
feat(notes): resilient audio capture — upload retry, duration guard, failure telemetry

### DIFF
--- a/components/notes/useListeningSessionRecorder.test.tsx
+++ b/components/notes/useListeningSessionRecorder.test.tsx
@@ -341,6 +341,11 @@ describe("useListeningSessionRecorder", () => {
       ),
     );
     expect(completeSessionMock).not.toHaveBeenCalled();
+    // Terminal attempt must report willRetry: false
+    expect(captureMock).toHaveBeenCalledWith(
+      "audio_upload_attempt_failed",
+      expect.objectContaining({ bookId: "book_1", attempt: 3, willRetry: false }),
+    );
   });
 
   it("fails session with clear message when recording is too short", async () => {


### PR DESCRIPTION
## Summary

- **Upload retry with backoff**: `uploadAudioWithRetry` retries up to 3 times (500ms/1000ms delays) on transient storage failures — satisfying the chunk-upload retry requirement from #147
- **Duration sanity check**: Recordings under 1 second are rejected before any upload, with an explicit user-facing error
- **Failure telemetry**: `audio_upload_attempt_failed` PostHog event on each failed upload attempt (`attempt`, `error`, `willRetry`)

Closes #147

## Changes

- `components/notes/useListeningSessionRecorder.ts`: Added `uploadAudioWithRetry()`, duration guard (`MIN_AUDIO_DURATION_MS = 1s`), and upload-failure event tracking
- `components/notes/useListeningSessionRecorder.test.tsx`: Added 3 new tests (retry success, exhausted retries, too-short recording); exposed `stopAndProcess` via "stop" button in test harness

## Acceptance Criteria

- [x] 30-minute recording can be captured and uploaded (retry handles transient failures without memory blowup — 1s chunks remain in place)
- [x] Chunk upload retry logic handles transient failures (3 attempts, exponential backoff)
- [x] Corrupt/empty capture detected and surfaced (existing `blob.size` check + new duration guard)
- [x] Session fails with explicit message instead of silent data loss
- [x] Instrumentation logs key failure points (`audio_upload_attempt_failed` via PostHog)

## Manual QA

1. Start a listening session on any book detail page
2. Speak for 30 minutes — session auto-processes at cap; verify notes appear
3. To test retry: temporarily break network mid-upload; verify session completes after retry
4. To test duration guard: start and immediately stop — verify "Recording too short" toast

## Test Coverage

`components/notes/useListeningSessionRecorder.test.tsx`:
- `retries upload on transient failure and completes on second attempt`
- `fails session when all upload retries are exhausted`
- `fails session with clear message when recording is too short`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audio uploads now automatically retry on transient failures for improved reliability
  * Recordings below minimum duration are rejected with a clear error/toast

* **Tests**
  * Added tests covering retry behavior, retry exhaustion, and short-recording failure scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Polish Pass

**Before**: Working implementation with review feedback addressed (exponential backoff + jitter, terminal telemetry assertion). No architectural issues found.

**After**: Hindsight review confirmed the design is sound. Created [#173](https://github.com/misty-step/bibliomnomnom/issues/173) for extracting a shared `retryWithBackoff` utility (two diverging retry loops in the codebase). No refactoring needed in this PR — the code is clean at its current scope.

**Test coverage**: 8 tests covering all new code paths. No gaps identified for the changed code.