### PR TITLE
fix: harden PostHog privacy + lower Sentry sample rate

### DIFF
--- a/components/providers/PostHogProvider.tsx
+++ b/components/providers/PostHogProvider.tsx
@@ -15,11 +15,12 @@ export function PostHogProvider({ children }: { children: ReactNode }) {
       posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
         // Use reverse proxy to bypass ad blockers
         api_host: "/ingest",
-        ui_host: "https://us.i.posthog.com",
+        ui_host: "https://us.posthog.com",
         // Only create person profiles for identified users
         person_profiles: "identified_only",
         // Manual pageview tracking via PostHogPageview component
         capture_pageview: false,
+        respect_dnt: true,
         // Privacy: mask all text and inputs in session recordings
         session_recording: {
           maskAllInputs: true,

--- a/lib/sentry-config.ts
+++ b/lib/sentry-config.ts
@@ -135,8 +135,7 @@ export function scrubPii(event: ErrorEvent): ErrorEvent | null {
 export const baseConfig = {
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.VERCEL_ENV || process.env.NODE_ENV,
-  // MVP: Higher sample rates while traffic is low, reduce as scale increases
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.1,
   sendDefaultPii: false,
   enabled: process.env.NODE_ENV === "production" || !!process.env.NEXT_PUBLIC_SENTRY_DSN,
   beforeSend: scrubPii,


### PR DESCRIPTION
## Summary
Hardens PostHog privacy defaults and reduces Sentry trace sampling to sustainable levels.

## Changes
- **PostHog**: add `respect_dnt: true`, fix `ui_host` URL (was `us.i.posthog.com`, now `us.posthog.com`)
- **Sentry**: lower `tracesSampleRate` from 1.0 to 0.1 (was set high for MVP, now at production-safe level)

## Test plan
- [ ] Verify Sentry still receives errors with reduced sampling
- [ ] Verify PostHog toolbar/heatmaps work with corrected `ui_host`
- [ ] Verify DNT header is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced privacy controls by enabling respect for Do Not Track (DNT) browser setting.
  * Optimized error tracking efficiency by reducing diagnostic trace sampling rate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->